### PR TITLE
Add text honeytoken component, disable submit until type is selected.

### DIFF
--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -27,7 +27,7 @@ function Header() {
   const [showCreatePopup, setShowCreatePopup] = useState(false);
   const [showAddAgentPopup, setShowAddAgentPopup] = useState(false);
 
-  const honeytokenTypes = [{ id: '1', name: 'text file' }];
+  const honeytokenTypes = [{ id: 'text', name: 'text file' }];
   const agents = useAgents();
 
   return (

--- a/client/src/components/HoneyTokenCreation.tsx
+++ b/client/src/components/HoneyTokenCreation.tsx
@@ -12,6 +12,7 @@ import {
 import '../styles/HoneyTokenCreation.css';
 import { getAgents } from '../models/Agents';
 import { createHoneytokenText } from '../models/Honeytoken';
+import TextHoneyToken from './TextHoneyToken';
 
 function CreateHoneytokenForm({ types, onClose }: any) {
   const [quantity, setQuantity] = useState<number>(1);
@@ -55,22 +56,21 @@ function CreateHoneytokenForm({ types, onClose }: any) {
 
             <p>
               <label>Type</label>
-              <Select
-                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                  setSelectedType(e.target.value)
-                }
+              <select
+                value={selectedType}
+                onChange={(e) => setSelectedType(e.target.value)}
+                style={{ color: selectedType === '' ? '#888' : 'black' }}
+                className="select-type"
               >
-                <SelectTrigger>
-                  <SelectValue placeholder="Select Honeytoken Type" />
-                </SelectTrigger>
-                <SelectContent>
-                  {types.map((type: any) => (
-                    <SelectItem key={type.id} value={type.id}>
-                      {type.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                <option value="" disabled hidden>
+                  Select Honeytoken Type
+                </option>
+                {types.map((type: any) => (
+                  <option key={type.id} value={type.id}>
+                    {type.name}
+                  </option>
+                ))}
+              </select>
             </p>
 
             {/* <p>
@@ -97,29 +97,16 @@ function CreateHoneytokenForm({ types, onClose }: any) {
               />
             </p>
 
-            <p>
-              <label>File Name</label>
-              <Input
-                type="text"
-                placeholder="Enter file name"
-                value={fileName}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setFileName(e.target.value)
-                }
+            {selectedType === 'text' && (
+              <TextHoneyToken
+                fileName={fileName}
+                setFileName={setFileName}
+                fileContent={fileContent}
+                setFileContent={setFileContent}
+                fileLocation={ComponentAddresses}
+                setFileLocation={setComponentAddresses}
               />
-            </p>
-
-            <p>
-              <label>File Content</label>
-              <Input
-                type="text"
-                placeholder="Enter the content of the file"
-                value={fileContent}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setFileContent(e.target.value)
-                }
-              />
-            </p>
+            )}
 
             <p>
               <label>Grade </label>
@@ -180,24 +167,6 @@ function CreateHoneytokenForm({ types, onClose }: any) {
                 <label>Spread Tokens Automatically</label>
               </div>
             </p> */}
-
-            {!spreadAuto && (selectedType || types.length < 2) && (
-              <p>
-                <label>File Location</label>
-                <div
-                  style={{ display: 'flex', gap: '8px', alignItems: 'center' }}
-                >
-                  <Input
-                    type="text"
-                    placeholder="Enter file path or click to choose"
-                    value={ComponentAddresses}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      setComponentAddresses(e.target.value)
-                    }
-                  />
-                </div>
-              </p>
-            )}
           </div>
 
           <div className="button-container">
@@ -207,6 +176,7 @@ function CreateHoneytokenForm({ types, onClose }: any) {
 
             <button
               className="button button-primary"
+              disabled={selectedType === ''}
               onClick={async () => {
                 if (quantity === 1) {
                   try {

--- a/client/src/components/TextHoneyToken.tsx
+++ b/client/src/components/TextHoneyToken.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Input } from './popup';
+
+interface TextHoneyTokenProps {
+  fileName: string;
+  setFileName: React.Dispatch<React.SetStateAction<string>>;
+  fileContent: string;
+  setFileContent: React.Dispatch<React.SetStateAction<string>>;
+  fileLocation: string;
+  setFileLocation: React.Dispatch<React.SetStateAction<string>>;
+}
+
+function TextHoneyToken({
+  fileName,
+  setFileName,
+  fileContent,
+  setFileContent,
+  fileLocation,
+  setFileLocation,
+}: TextHoneyTokenProps) {
+  return (
+    <>
+      <p>
+        <label>File Name</label>
+        <Input
+          type="text"
+          placeholder="Enter file name"
+          value={fileName}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setFileName(e.target.value)
+          }
+        />
+      </p>
+
+      <p>
+        <label>File Content</label>
+        <Input
+          type="text"
+          placeholder="Enter the content of the file"
+          value={fileContent}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setFileContent(e.target.value)
+          }
+        />
+      </p>
+
+      <p>
+        <label>File Location</label>
+        <Input
+          type="text"
+          placeholder="Enter file path"
+          value={fileLocation}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setFileLocation(e.target.value)
+          }
+        />
+      </p>
+    </>
+  );
+}
+
+export default TextHoneyToken;

--- a/client/src/styles/HoneyTokenCreation.css
+++ b/client/src/styles/HoneyTokenCreation.css
@@ -107,6 +107,14 @@ select:focus {
   transform: scale(1.05);
 }
 
+.button:disabled {
+  background-color: #d1d5db;
+  color: #9ca3af;
+  cursor: not-allowed;
+  transform: none !important;
+  box-shadow: none !important;
+}
+
 .checkbox-container {
   display: flex;
   align-items: center;
@@ -129,4 +137,14 @@ select:focus {
   align-items: center;
   justify-content: center;
   z-index: 9999;
+}
+
+select:invalid {
+  color: #888;
+}
+
+.popup-content > p {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 }


### PR DESCRIPTION
I created a separate component for the selected honeytoken type (for now only text).
Once a text file is selected, all fields relevant to that token will open in a popup.
The submit button will not be clickable until a type is selected