### PR TITLE
Add API honeytoken dashboard with grouping by group ID

### DIFF
--- a/client/src/models/Honeytoken.tsx
+++ b/client/src/models/Honeytoken.tsx
@@ -111,9 +111,7 @@ export async function isHoneytokenMonitored(token_id: string): Promise<boolean> 
   }
 }
 
-export async function getHoneytokensMonitorStatuses(): Promise<
-  Record<string, boolean>
-> {
+export async function getHoneytokensMonitorStatuses(): Promise<Record<string, boolean>> {
   try {
     const agents_data: IAgentStatus[] = await areAgentsConnected();
 
@@ -125,16 +123,13 @@ export async function getHoneytokensMonitorStatuses(): Promise<
       return {}; // Early exit if no online agents
     }
 
-    const response = await fetch(
-      'http://localhost:3000/api/honeytokens/monitor_status',
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ agents_ids }),
+    const response = await fetch('http://localhost:3000/api/honeytokens/monitor_status', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
       },
-    );
+      body: JSON.stringify({ agents_ids }),
+    });
 
     if (!response.ok) {
       throw new Error('Failed to fetch monitoring statuses');
@@ -146,5 +141,52 @@ export async function getHoneytokensMonitorStatuses(): Promise<
   } catch (err) {
     console.error('Error fetching monitoring statuses:', err);
     return {};
+  }
+}
+
+export async function deleteHoneytokensByGroupId(group_id: string) {
+  try {
+    const response = await fetch(`http://localhost:3000/api/honeytokens/group/${group_id}`, {
+      method: 'DELETE',
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+  } catch (err) {
+    console.error('Error deleting honeytokens group:', err);
+  }
+}
+
+export async function startMonitorByGroupId(group_id: string) {
+  try {
+    const response = await fetch(`http://localhost:3000/api/honeytokens/start/group`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ group_id }),
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+  } catch (err) {
+    console.error('Error starting monitor on group:', err);
+  }
+}
+
+export async function stopMonitorByGroupId(group_id: string) {
+  try {
+    const response = await fetch(`http://localhost:3000/api/honeytokens/stop/group`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ group_id }),
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+  } catch (err) {
+    console.error('Error stopping monitor on group:', err);
   }
 }

--- a/client/src/pages/Honeytokens.tsx
+++ b/client/src/pages/Honeytokens.tsx
@@ -6,6 +6,9 @@ import {
   startMonitorOnHoneytoken,
   stopMonitorOnHoneytoken,
   getHoneytokensMonitorStatuses,
+  deleteHoneytokensByGroupId,
+  startMonitorByGroupId,
+  stopMonitorByGroupId,
 } from '../models/Honeytoken';
 import { IHoneytoken } from '../../../server/interfaces/honeytoken';
 import { FaTrash, FaPlay, FaStop } from 'react-icons/fa';
@@ -16,6 +19,9 @@ function Honeytokens() {
   const [refreshCounter, setRefreshCounter] = useState(0);
   const [hoveredIcon, setHoveredIcon] = useState<string | null>(null);
   const [isReversed, setIsReversed] = useState(false);
+  const [activeTab, setActiveTab] = useState<'text' | 'api'>('text');
+  const [loadingGroupId, setLoadingGroupId] = useState<string | null>(null);
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
 
   // 👇 NEW STATE
   const [loadingTokenId, setLoadingTokenId] = useState<string | null>(null);
@@ -27,12 +33,10 @@ function Honeytokens() {
 
         const monitoringStatuses = await getHoneytokensMonitorStatuses();
 
-        const tokensWithMonitoringStatus = tokenData.map(
-          (token: IHoneytoken) => ({
-            ...token,
-            isMonitored: monitoringStatuses[token.token_id] ?? false,
-          }),
-        );
+        const tokensWithMonitoringStatus = tokenData.map((token: IHoneytoken) => ({
+          ...token,
+          isMonitored: monitoringStatuses[token.token_id] ?? false,
+        }));
 
         setHoneytokens(tokensWithMonitoringStatus);
       } catch (error) {
@@ -60,9 +64,7 @@ function Honeytokens() {
       setLoadingTokenId(tokenId); // 👈
       await startMonitorOnHoneytoken(tokenId);
       setHoneytokens((prevTokens) =>
-        prevTokens.map((token) =>
-          token.token_id === tokenId ? { ...token, isMonitored: true } : token,
-        ),
+        prevTokens.map((token) => (token.token_id === tokenId ? { ...token, isMonitored: true } : token)),
       );
     } catch (error) {
       console.error('Failed to start monitoring honeytoken:', error);
@@ -76,9 +78,7 @@ function Honeytokens() {
       setLoadingTokenId(tokenId); // 👈
       await stopMonitorOnHoneytoken(tokenId);
       setHoneytokens((prevTokens) =>
-        prevTokens.map((token) =>
-          token.token_id === tokenId ? { ...token, isMonitored: false } : token,
-        ),
+        prevTokens.map((token) => (token.token_id === tokenId ? { ...token, isMonitored: false } : token)),
       );
     } catch (error) {
       console.error('Failed to stop monitoring honeytoken:', error);
@@ -87,173 +87,351 @@ function Honeytokens() {
     }
   };
 
+  const handleDeleteGroup = async (groupId: string) => {
+    try {
+      setLoadingGroupId(groupId);
+      await deleteHoneytokensByGroupId(groupId);
+      setRefreshCounter((prev) => prev + 1);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoadingGroupId(null);
+    }
+  };
+
+  const handleStartGroup = async (groupId: string) => {
+    try {
+      setLoadingGroupId(groupId);
+      await startMonitorByGroupId(groupId);
+      setRefreshCounter((prev) => prev + 1);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoadingGroupId(null);
+    }
+  };
+
+  const handleStopGroup = async (groupId: string) => {
+    try {
+      setLoadingGroupId(groupId);
+      await stopMonitorByGroupId(groupId);
+      setRefreshCounter((prev) => prev + 1);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoadingGroupId(null);
+    }
+  };
+
   const handleReverseClick = () => {
     setHoneytokens((prev) => [...prev].reverse());
     setIsReversed((prev) => !prev);
   };
 
+  const renderTextTable = () => {
+    const textTokens = honeytokens.filter((t) => t.type_id !== 'api');
+    return (
+      <div className="honeytokens-container">
+        <div className="honeytokens-refresh-button-wrapper">
+          <button
+            className="honeytokens-refresh-button"
+            onClick={() => setRefreshCounter((prev) => prev + 1)}
+            disabled={loadingTokenId !== null} // 👈 Prevent refresh during actions
+          >
+            Refresh Statuses
+          </button>
+        </div>
+        <div className="table-container">
+          <table className="honeytokens-table">
+            <thead>
+              <tr>
+                <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
+                  Agent ID {isReversed ? <FiChevronUp /> : <FiChevronDown />}
+                </th>
+                <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
+                  Token ID {isReversed ? <FiChevronUp /> : <FiChevronDown />}
+                </th>
+                <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
+                  Group ID {isReversed ? <FiChevronUp /> : <FiChevronDown />}
+                </th>
+                <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
+                  Type ID {isReversed ? <FiChevronUp /> : <FiChevronDown />}
+                </th>
+                <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
+                  Creation Date {isReversed ? <FiChevronUp /> : <FiChevronDown />}
+                </th>
+                <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
+                  Expire Date {isReversed ? <FiChevronUp /> : <FiChevronDown />}
+                </th>
+                <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
+                  Location {isReversed ? <FiChevronUp /> : <FiChevronDown />}
+                </th>
+                <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
+                  File Name {isReversed ? <FiChevronUp /> : <FiChevronDown />}
+                </th>
+                <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
+                  Data {isReversed ? <FiChevronUp /> : <FiChevronDown />}
+                </th>
+                <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
+                  Notes {isReversed ? <FiChevronUp /> : <FiChevronDown />}
+                </th>
+                <th>Status</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+
+            <tbody>
+              {textTokens.length > 0 ? (
+                textTokens.map((honeytoken) => (
+                  <tr key={honeytoken.token_id}>
+                    <td>{honeytoken.agent_id}</td>
+                    <td>{honeytoken.token_id}</td>
+                    <td>{honeytoken.group_id}</td>
+                    <td>{honeytoken.type_id}</td>
+                    <td>{new Date(honeytoken.creation_date).toLocaleString()}</td>
+                    <td>{new Date(honeytoken.expire_date).toLocaleString()}</td>
+                    <td>{honeytoken.location}</td>
+                    <td>{honeytoken.file_name}</td>
+                    <td>{honeytoken.data}</td>
+                    <td>{honeytoken.notes}</td>
+                    <td>
+                      <span className={`honeytoken-status-${honeytoken.isMonitored ? 'monitored' : 'not-monitored'}`}>
+                        {honeytoken.isMonitored ? 'Monitored' : 'Not Monitored'}
+                      </span>
+                    </td>
+                    <td>
+                      <div className="action-icons-text">
+                        {honeytoken.isMonitored ? (
+                          <button
+                            onClick={() => handleStopMonitoring(honeytoken.token_id)}
+                            onMouseEnter={() => setHoveredIcon(`stop-${honeytoken.token_id}`)}
+                            onMouseLeave={() => setHoveredIcon(null)}
+                            title="Stop Monitoring"
+                            disabled={loadingTokenId === honeytoken.token_id} // 👈
+                            style={{
+                              opacity: loadingTokenId === honeytoken.token_id ? 0.5 : 1,
+                              pointerEvents: loadingTokenId === honeytoken.token_id ? 'none' : 'auto',
+                            }}
+                          >
+                            <FaStop
+                              className={`action-icon stop ${hoveredIcon === `stop-${honeytoken.token_id}` ? 'hovered' : ''}`}
+                            />
+                          </button>
+                        ) : (
+                          <button
+                            onClick={() => handleStartMonitoring(honeytoken.token_id)}
+                            onMouseEnter={() => setHoveredIcon(`start-${honeytoken.token_id}`)}
+                            onMouseLeave={() => setHoveredIcon(null)}
+                            title="Start Monitoring"
+                            disabled={loadingTokenId === honeytoken.token_id} // 👈
+                            style={{
+                              opacity: loadingTokenId === honeytoken.token_id ? 0.5 : 1,
+                              pointerEvents: loadingTokenId === honeytoken.token_id ? 'none' : 'auto',
+                            }}
+                          >
+                            <FaPlay
+                              className={`action-icon start ${hoveredIcon === `start-${honeytoken.token_id}` ? 'hovered' : ''}`}
+                            />
+                          </button>
+                        )}
+                        <button
+                          onClick={() => handleDeleteHoneytoken(honeytoken.token_id)}
+                          onMouseEnter={() => setHoveredIcon(`delete-${honeytoken.token_id}`)}
+                          onMouseLeave={() => setHoveredIcon(null)}
+                          title="Delete Honeytoken"
+                          disabled={loadingTokenId === honeytoken.token_id} // 👈
+                          style={{
+                            opacity: loadingTokenId === honeytoken.token_id ? 0.5 : 1,
+                            pointerEvents: loadingTokenId === honeytoken.token_id ? 'none' : 'auto',
+                          }}
+                        >
+                          <FaTrash
+                            className={`action-icon delete ${hoveredIcon === `delete-${honeytoken.token_id}` ? 'hovered' : ''}`}
+                          />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={12} className="no-honeytokens">
+                    No honeytokens found
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  };
+
+  const renderApiTable = () => {
+    const apiTokens = honeytokens.filter((t) => t.type_id === 'api');
+    console.log('API TOKENS RECEIVED FROM SERVER:', apiTokens);
+
+    const groups = apiTokens.reduce(
+      (acc, token) => {
+        if (!acc[token.group_id]) acc[token.group_id] = [];
+        acc[token.group_id].push(token);
+        return acc;
+      },
+      {} as Record<string, IHoneytoken[]>,
+    );
+
+    return (
+      <div className="honeytokens-container">
+        <div className="honeytokens-refresh-button-wrapper">
+          <button
+            className="honeytokens-refresh-button"
+            onClick={() => setRefreshCounter((prev) => prev + 1)}
+            disabled={loadingTokenId !== null} // 👈 Prevent refresh during actions
+          >
+            Refresh Statuses
+          </button>
+        </div>
+
+        <div className="table-container">
+          <table className="honeytokens-table">
+            <tbody>
+              {Object.entries(groups).map(([groupId, tokens]) => {
+                const first = tokens[0];
+                const expanded = expandedGroups[groupId];
+                return (
+                  <>
+                    <tr key={groupId} className="group-row">
+                      <td colSpan={12}>
+                        <div className="group-header-row">
+                          <span>
+                            <strong>Group:</strong> {groupId}
+                          </span>
+                          <span>
+                            <strong>Creation:</strong> {new Date(first.creation_date).toLocaleString()}
+                          </span>
+                          <span>
+                            <strong>Expire:</strong> {new Date(first.expire_date).toLocaleString()}
+                          </span>
+                          <span>
+                            <strong>Port:</strong> {first.api_port}
+                          </span>
+                          <span className={`honeytoken-status-${first.isMonitored ? 'monitored' : 'not-monitored'}`}>
+                            {first.isMonitored ? 'Monitored' : 'Not Monitored'}
+                          </span>
+                          <div className="action-icons-api">
+                            {first.isMonitored ? (
+                              <button
+                                onClick={() => handleStopGroup(groupId)}
+                                onMouseEnter={() => setHoveredIcon(`stop-${groupId}`)}
+                                onMouseLeave={() => setHoveredIcon(null)}
+                                title="Stop Monitoring"
+                                disabled={loadingGroupId === groupId}
+                                style={{
+                                  opacity: loadingGroupId === groupId ? 0.5 : 1,
+                                  pointerEvents: loadingGroupId === groupId ? 'none' : 'auto',
+                                }}
+                              >
+                                <FaStop
+                                  className={`action-icon stop ${hoveredIcon === `stop-${groupId}` ? 'hovered' : ''}`}
+                                />
+                              </button>
+                            ) : (
+                              <button
+                                onClick={() => handleStartGroup(groupId)}
+                                onMouseEnter={() => setHoveredIcon(`start-${groupId}`)}
+                                onMouseLeave={() => setHoveredIcon(null)}
+                                title="Start Monitoring"
+                                disabled={loadingGroupId === groupId}
+                                style={{
+                                  opacity: loadingGroupId === groupId ? 0.5 : 1,
+                                  pointerEvents: loadingGroupId === groupId ? 'none' : 'auto',
+                                }}
+                              >
+                                <FaPlay
+                                  className={`action-icon start ${hoveredIcon === `start-${groupId}` ? 'hovered' : ''}`}
+                                />
+                              </button>
+                            )}
+
+                            <button
+                              onClick={() => handleDeleteGroup(groupId)}
+                              onMouseEnter={() => setHoveredIcon(`delete-${groupId}`)}
+                              onMouseLeave={() => setHoveredIcon(null)}
+                              title="Delete Group"
+                              disabled={loadingGroupId === groupId}
+                              style={{
+                                opacity: loadingGroupId === groupId ? 0.5 : 1,
+                                pointerEvents: loadingGroupId === groupId ? 'none' : 'auto',
+                              }}
+                            >
+                              <FaTrash
+                                className={`action-icon delete ${hoveredIcon === `delete-${groupId}` ? 'hovered' : ''}`}
+                              />
+                            </button>
+                          </div>
+
+                          <button
+                            onClick={() => setExpandedGroups((prev) => ({ ...prev, [groupId]: !prev[groupId] }))}
+                            className="expand-button"
+                            title="Expand/Collapse"
+                          >
+                            {expanded ? '▲' : '▼'}
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+
+                    {expanded && (
+                      <>
+                        <tr className="sub-header">
+                          <th colSpan={12}>
+                            <table className="sub-token-table">
+                              <thead>
+                                <tr>
+                                  <th>Method</th>
+                                  <th>Route</th>
+                                  <th>Response</th>
+                                  <th>Token ID</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {tokens.map((token) => (
+                                  <tr key={token.token_id}>
+                                    <td>{token.http_method}</td>
+                                    <td>{token.route}</td>
+                                    <td>{token.response}</td>
+                                    <td>{token.token_id}</td>
+                                  </tr>
+                                ))}
+                              </tbody>
+                            </table>
+                          </th>
+                        </tr>
+                      </>
+                    )}
+                  </>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    );
+  };
   return (
     <div className="honeytokens-container">
       <h1 className="honeytokens-title">Honeytokens Dashboard</h1>
 
-      <div className="honeytokens-refresh-button-wrapper">
-        <button
-          className="honeytokens-refresh-button"
-          onClick={() => setRefreshCounter((prev) => prev + 1)}
-          disabled={loadingTokenId !== null} // 👈 Prevent refresh during actions
-        >
-          Refresh Statuses
+      <div className="tab-buttons">
+        <button className={`tab-button ${activeTab === 'text' ? 'active' : ''}`} onClick={() => setActiveTab('text')}>
+          Text Tokens
+        </button>
+        <button className={`tab-button ${activeTab === 'api' ? 'active' : ''}`} onClick={() => setActiveTab('api')}>
+          API Tokens
         </button>
       </div>
 
-      <div className="table-container">
-        <table className="honeytokens-table">
-          <thead>
-            <tr>
-              <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
-                Agent ID {isReversed ? <FiChevronUp /> : <FiChevronDown />}
-              </th>
-              <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
-                Token ID {isReversed ? <FiChevronUp /> : <FiChevronDown />}
-              </th>
-              <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
-                Group ID {isReversed ? <FiChevronUp /> : <FiChevronDown />}
-              </th>
-              <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
-                Type ID {isReversed ? <FiChevronUp /> : <FiChevronDown />}
-              </th>
-              <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
-                Creation Date {isReversed ? <FiChevronUp /> : <FiChevronDown />}
-              </th>
-              <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
-                Expire Date {isReversed ? <FiChevronUp /> : <FiChevronDown />}
-              </th>
-              <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
-                Location {isReversed ? <FiChevronUp /> : <FiChevronDown />}
-              </th>
-              <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
-                File Name {isReversed ? <FiChevronUp /> : <FiChevronDown />}
-              </th>
-              <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
-                Data {isReversed ? <FiChevronUp /> : <FiChevronDown />}
-              </th>
-              <th onClick={handleReverseClick} style={{ cursor: 'pointer' }}>
-                Notes {isReversed ? <FiChevronUp /> : <FiChevronDown />}
-              </th>
-              <th>Status</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-
-          <tbody>
-            {honeytokens.length > 0 ? (
-              honeytokens.map((honeytoken) => (
-                <tr key={honeytoken.token_id}>
-                  <td>{honeytoken.agent_id}</td>
-                  <td>{honeytoken.token_id}</td>
-                  <td>{honeytoken.group_id}</td>
-                  <td>{honeytoken.type_id}</td>
-                  <td>{new Date(honeytoken.creation_date).toLocaleString()}</td>
-                  <td>{new Date(honeytoken.expire_date).toLocaleString()}</td>
-                  <td>{honeytoken.location}</td>
-                  <td>{honeytoken.file_name}</td>
-                  <td>{honeytoken.data}</td>
-                  <td>{honeytoken.notes}</td>
-                  <td>
-                    <span
-                      className={`honeytoken-status-${honeytoken.isMonitored ? 'monitored' : 'not-monitored'}`}
-                    >
-                      {honeytoken.isMonitored ? 'Monitored' : 'Not Monitored'}
-                    </span>
-                  </td>
-                  <td>
-                    <div className="action-icons">
-                      {honeytoken.isMonitored ? (
-                        <button
-                          onClick={() =>
-                            handleStopMonitoring(honeytoken.token_id)
-                          }
-                          onMouseEnter={() =>
-                            setHoveredIcon(`stop-${honeytoken.token_id}`)
-                          }
-                          onMouseLeave={() => setHoveredIcon(null)}
-                          title="Stop Monitoring"
-                          disabled={loadingTokenId === honeytoken.token_id} // 👈
-                          style={{
-                            opacity:
-                              loadingTokenId === honeytoken.token_id ? 0.5 : 1,
-                            pointerEvents:
-                              loadingTokenId === honeytoken.token_id
-                                ? 'none'
-                                : 'auto',
-                          }}
-                        >
-                          <FaStop
-                            className={`action-icon stop ${hoveredIcon === `stop-${honeytoken.token_id}` ? 'hovered' : ''}`}
-                          />
-                        </button>
-                      ) : (
-                        <button
-                          onClick={() =>
-                            handleStartMonitoring(honeytoken.token_id)
-                          }
-                          onMouseEnter={() =>
-                            setHoveredIcon(`start-${honeytoken.token_id}`)
-                          }
-                          onMouseLeave={() => setHoveredIcon(null)}
-                          title="Start Monitoring"
-                          disabled={loadingTokenId === honeytoken.token_id} // 👈
-                          style={{
-                            opacity:
-                              loadingTokenId === honeytoken.token_id ? 0.5 : 1,
-                            pointerEvents:
-                              loadingTokenId === honeytoken.token_id
-                                ? 'none'
-                                : 'auto',
-                          }}
-                        >
-                          <FaPlay
-                            className={`action-icon start ${hoveredIcon === `start-${honeytoken.token_id}` ? 'hovered' : ''}`}
-                          />
-                        </button>
-                      )}
-                      <button
-                        onClick={() =>
-                          handleDeleteHoneytoken(honeytoken.token_id)
-                        }
-                        onMouseEnter={() =>
-                          setHoveredIcon(`delete-${honeytoken.token_id}`)
-                        }
-                        onMouseLeave={() => setHoveredIcon(null)}
-                        title="Delete Honeytoken"
-                        disabled={loadingTokenId === honeytoken.token_id} // 👈
-                        style={{
-                          opacity:
-                            loadingTokenId === honeytoken.token_id ? 0.5 : 1,
-                          pointerEvents:
-                            loadingTokenId === honeytoken.token_id
-                              ? 'none'
-                              : 'auto',
-                        }}
-                      >
-                        <FaTrash
-                          className={`action-icon delete ${hoveredIcon === `delete-${honeytoken.token_id}` ? 'hovered' : ''}`}
-                        />
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))
-            ) : (
-              <tr>
-                <td colSpan={12} className="no-honeytokens">
-                  No honeytokens found
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
+      {activeTab === 'text' ? renderTextTable() : renderApiTable()}
     </div>
   );
 }

--- a/client/src/styles/Honeytokens.css
+++ b/client/src/styles/Honeytokens.css
@@ -70,10 +70,17 @@
   color: #1f2937;
 }
 
-.action-icons {
+.action-icons-text {
   display: flex;
   justify-content: center;
   gap: 8px;
+}
+
+.action-icons-api {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-left: 3rem;
 }
 
 .action-icon {
@@ -154,4 +161,77 @@
 
 .honeytokens-refresh-button:hover {
   background-color: #2563eb;
+}
+
+.group-header-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.9rem;
+  color: #1f2937;
+  font-weight: 500;
+}
+
+.group-header-row span::after {
+  content: '|';
+  margin: 0 8px;
+  color: #d1d5db;
+}
+
+.group-header-row span:last-of-type::after {
+  content: '';
+  margin: 0;
+}
+
+.expand-button {
+  background: none;
+  border: none;
+  color: black;
+  font-size: 1rem;
+  cursor: pointer;
+  margin-left: auto;
+  padding: 0;
+  transform: scale(1.3);
+}
+
+.sub-token-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+}
+
+.sub-token-table th,
+.sub-token-table td {
+  padding: 0.75rem;
+  text-align: center;
+  border: 1px solid #e5e7eb;
+  font-size: 0.875rem;
+  color: #1f2937;
+}
+
+.tab-buttons {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+  gap: 3rem;
+}
+
+.tab-button {
+  background: none;
+  border: none;
+  font-size: 1rem;
+  font-weight: 600;
+  padding-bottom: 0.5rem;
+  cursor: pointer;
+  color: #374151;
+  position: relative;
+}
+
+.tab-button.active {
+  color: black;
+  border-bottom: 2px solid black;
+}
+
+.tab-button:hover {
+  color: #111827;
 }

--- a/server/interfaces/honeytoken.ts
+++ b/server/interfaces/honeytoken.ts
@@ -10,4 +10,8 @@ export interface IHoneytoken {
   data: string;
   notes?: string;
   isMonitored: boolean;
+  route?: string;
+  http_method?: string;
+  response?: string;
+  api_port?: string;
 }

--- a/server/routes/honeytokens.ts
+++ b/server/routes/honeytokens.ts
@@ -14,6 +14,7 @@ import { Globals } from '../globals';
 import { get_agent_by_id, get_agent_by_uri } from '../database/agents';
 import { v4 as uuidv4 } from 'uuid';
 import { Constants } from '../constants';
+import { IHoneytoken } from '../interfaces/honeytoken';
 
 export function serveHoneytokens() {
   const router = Router();
@@ -153,8 +154,8 @@ export function serveHoneytokens() {
             token_id: token_id,
             group_id: group_id,
             type: type,
-            file_name: http_method,
-            location: route,
+            http_method: http_method,
+            route: route,
             grade: grade,
             expiration_date: expiration_date,
             notes: notes,
@@ -301,11 +302,36 @@ export function serveHoneytokens() {
 
   router.delete('/honeytokens/group/:group_id', async (req, res) => {
     const { group_id } = req.params;
+
     try {
+      const tokens = await get_honeytokens_by_group_id(group_id);
+      const apiTokens = tokens.filter((token: IHoneytoken) => token.type_id === '2');
+
+      for (const token of apiTokens) {
+        const agent = await get_agent_by_id(token.agent_id);
+        if (!agent) continue;
+
+        const response_from_agent = await fetch(`http://${agent.agent_ip}:${agent.agent_port}/api/honeytoken/remove`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token_id: token.token_id }),
+        });
+
+        if (!response_from_agent.ok) {
+          console.warn(`[!] Failed to remove token ${token.token_id} from agent ${agent.agent_ip}`);
+        }
+      }
+
       await delete_honeytokens_by_group_id(group_id);
-      res.json({ success: true });
+
+      res.json({ success: `Deleted API tokens in group_id ${group_id}` });
     } catch (error) {
-      console.error(Constants.TEXT_RED_COLOR, 'Failed to delete honeytokens:', error, Constants.TEXT_WHITE_COLOR);
+      console.error(
+        Constants.TEXT_RED_COLOR,
+        'Failed to delete honeytokens in group:',
+        error,
+        Constants.TEXT_WHITE_COLOR,
+      );
       res.status(500).json({ failure: error });
     }
   });
@@ -417,6 +443,50 @@ export function serveHoneytokens() {
     }
   });
 
+  router.put('/honeytokens/start/group', async (req, res) => {
+    const { group_id } = req.body;
+
+    try {
+      const tokens = await get_honeytokens_by_group_id(group_id);
+
+      const apiTokens = tokens.filter((token: IHoneytoken) => token.type_id === '2');
+
+      if (apiTokens.length === 0) {
+        res.status(404).json({ failure: 'No API tokens found for this group_id' });
+        return;
+      }
+
+      let atLeastOneSuccess = false;
+
+      for (const token of apiTokens) {
+        const agent = await get_agent_by_id(token.agent_id);
+        if (!agent) continue;
+
+        const response_from_agent = await fetch(
+          'http://' + agent.agent_ip + ':' + agent.agent_port + '/api/honeytoken/startgroup',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ token_id: token.token_id }),
+          },
+        );
+
+        if (response_from_agent.ok || response_from_agent.status === 200) {
+          atLeastOneSuccess = true;
+        }
+      }
+
+      if (atLeastOneSuccess) {
+        res.status(200).json({ success: 'Started monitor on API honeytokens in group' });
+      } else {
+        res.status(500).json({ failure: 'No agent responded as expected' });
+      }
+    } catch (error) {
+      console.error(Constants.TEXT_RED_COLOR, 'Failed to start monitor on group:', error, Constants.TEXT_WHITE_COLOR);
+      res.status(500).json({ failure: error });
+    }
+  });
+
   router.put('/honeytokens/stop', async (req, res) => {
     const { token_id } = req.body;
     try {
@@ -441,6 +511,50 @@ export function serveHoneytokens() {
       return;
     } catch (error) {
       console.error(Constants.TEXT_RED_COLOR, 'Failed to stop honeytoken:', error, Constants.TEXT_WHITE_COLOR);
+      res.status(500).json({ failure: error });
+    }
+  });
+
+  router.put('/honeytokens/stop/group', async (req, res) => {
+    const { group_id } = req.body;
+
+    try {
+      const tokens = await get_honeytokens_by_group_id(group_id);
+
+      const apiTokens = tokens.filter((token: IHoneytoken) => token.type_id === '2');
+
+      if (apiTokens.length === 0) {
+        res.status(404).json({ failure: 'No API tokens found for this group_id' });
+        return;
+      }
+
+      let atLeastOneSuccess = false;
+
+      for (const token of apiTokens) {
+        const agent = await get_agent_by_id(token.agent_id);
+        if (!agent) continue;
+
+        const response_from_agent = await fetch(
+          'http://' + agent.agent_ip + ':' + agent.agent_port + '/api/honeytoken/stopgroup',
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ token_id: token.token_id }),
+          },
+        );
+
+        if (response_from_agent.ok || response_from_agent.status === 200) {
+          atLeastOneSuccess = true;
+        }
+      }
+
+      if (atLeastOneSuccess) {
+        res.status(200).json({ success: 'Stopped monitor on API honeytokens in group' });
+      } else {
+        res.status(500).json({ failure: 'No agent responded as expected' });
+      }
+    } catch (error) {
+      console.error(Constants.TEXT_RED_COLOR, 'Failed to stop monitor on group:', error, Constants.TEXT_WHITE_COLOR);
       res.status(500).json({ failure: error });
     }
   });


### PR DESCRIPTION
Created a new dashboard tab specifically for API honeytokens.
Grouped API honeytokens by their group_id 
Implemented expand/collapse functionality for each group to show/hide individual tokens.
Displayed key details in the group header: Group ID, Creation Date, Expiration Date, API Port, and Monitoring Status.
Added action buttons on the group level for:
Starting monitoring on all tokens in the group.
Stopping monitoring on all tokens in the group.
Deleting all tokens in the group.
Added a nested table inside each expanded group showing the tokens with columns: Method, Route, Response, Token ID.